### PR TITLE
Update edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "git-tree"
 version = "0.1.5"
 authors = ["Christoph Rüßler <christoph.ruessler@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 description = "tree + git status: displays git status info in a tree"
 
 [dependencies]


### PR DESCRIPTION
Run `cargo fix --edition-idioms` and `cargo fmt`, though this did not
result in any changes.
